### PR TITLE
Fix issue with building jar

### DIFF
--- a/graph-gentool/build.gradle
+++ b/graph-gentool/build.gradle
@@ -67,3 +67,26 @@ tasks.withType(DokkaTask.class) {
             ["org.jetbrains.dokka.base.DokkaBase": dokkaBaseConfiguration]
     )
 }
+
+tasks.register('fatJar', Jar) {
+    group 'build'
+    manifest {
+        manifest {
+            attributes 'Main-Class': application.mainClass
+        }
+    }
+    duplicatesStrategy = DuplicatesStrategy.EXCLUDE
+    archiveClassifier = 'standalone'
+    from {
+        configurations.runtimeClasspath.collect { it.isDirectory() ? it : zipTree(it) }
+    } {
+        exclude "META-INF/*.SF"
+        exclude "META-INF/*.DSA"
+        exclude "META-INF/*.RSA"
+    }
+    with jar
+}
+
+artifacts {
+    archives fatJar
+}

--- a/graph-gentool/src/main/kotlin/ecore/EcoreHandler.kt
+++ b/graph-gentool/src/main/kotlin/ecore/EcoreHandler.kt
@@ -23,6 +23,7 @@ import org.eclipse.emf.ecore.resource.impl.ResourceSetImpl
 import org.eclipse.emf.ecore.util.BasicExtendedMetaData
 import org.eclipse.emf.ecore.util.ExtendedMetaData
 import org.eclipse.emf.ecore.xmi.XMLResource
+import org.eclipse.emf.ecore.xmi.XMLResource.MissingPackageHandler
 import org.eclipse.emf.ecore.xmi.impl.EcoreResourceFactoryImpl
 import org.eclipse.emf.ecore.xmi.impl.XMIResourceFactoryImpl
 import java.util.*
@@ -51,6 +52,14 @@ class EcoreHandler(metamodel: URI, model: URI, registryExtension: String) {
         } else {
             throw Exception("Unsupported ECORE specification.")
         }
+
+        val mph = object : MissingPackageHandler {
+            override fun getPackage(p0: String?): EPackage {
+                return metamodelRoot as EPackage
+            }
+        }
+
+        resourceSet!!.loadOptions[XMLResource.OPTION_MISSING_PACKAGE_HANDLER] = mph
 
         modelResource = resourceSet!!.getResource(model, true)
     }


### PR DESCRIPTION
Fix issue with building jars by...

- Using streams instead of resources to get static resources (templates and metamodels)
- Writing metamodel data to temporary files to provide them to EMF packages

Further adds...

- A standalone jar to the build process 
- Adds a workaround for `org.eclipse.emf.ecore.xmi.PackageNotFoundException` encountered with the jar: [Stack Overflow](https://stackoverflow.com/a/45441670)

Fixes #1 